### PR TITLE
Move theme rels

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @ryantmer

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @ryantmer
+* @ryantmer @jstefaniuk-d2l @CodeBaboon

--- a/d2l-hm-constants-behavior.html
+++ b/d2l-hm-constants-behavior.html
@@ -26,8 +26,6 @@
 			profileImage: 'https://api.brightspace.com/rels/profile-image',
 			root: 'https://api.brightspace.com/rels/root',
 			semesters: 'https://api.brightspace.com/rels/semesters',
-			theme: 'https://themes.api.brightspace.com/rels/theme',
-			themeLogo: 'https://themes.api.brightspace.com/rels/logo',
 			thumbnailRegular: 'https://api.brightspace.com/rels/thumbnail#regular',
 			thumbnailSmall: 'https://api.brightspace.com/rels/thumbnail#small',
 			userProfile: 'https://api.brightspace.com/rels/user-profile',
@@ -39,11 +37,11 @@
 				activityUsage: 'https://activities.api.brightspace.com/rels/activity-usage',
 				overdue: 'https://activities.api.brightspace.com/rels/overdue'
 			},
-			// Parents api sub-domain rels
+			// Parents API sub-domain rels
 			Parents: {
 				allChildren: 'https://parents.api.brightspace.com/rels/all-my-children'
 			},
-			// Folio api sub-domain rels
+			// Folio API sub-domain rels
 			Folio: {
 				contentItem: 'https://folio.api.brightspace.com/rels/Content',
 				commentList: 'https://folio.api.brightspace.com/rels/CommentList',
@@ -52,6 +50,11 @@
 				reflection: 'https://folio.api.brightspace.com/rels/Reflection',
 				courseInfo: 'https://folio.api.brightspace.com/rels/CourseInfo',
 				courseList: 'https://folio.api.brightspace.com/rels/CourseList'
+			},
+			// Themes API sub-domain rels
+			Themes: {
+				theme: 'https://themes.api.brightspace.com/rels/theme',
+				themeLogo: 'https://themes.api.brightspace.com/rels/logo',
 			}
 		},
 		HypermediaClasses: {


### PR DESCRIPTION
This is more inline with what we're doing with other rels, where anything on subdomain.api.brightspace.com maps to HypermediaRels.subdomain.relGoesHere.

This is a breaking change, so will come with a major version bump.

Also added `CODEOWNERS` with myself in it - anybody else want me to add them? Once we've got a few people in it, would be good to add the proper branch protection to require a review from a `CODEOWNER` (although I don't have perms to enable that on this repo)