### PR TITLE
Rename theme logo rel to be a bit less redundant

### DIFF
--- a/d2l-hm-constants-behavior.html
+++ b/d2l-hm-constants-behavior.html
@@ -54,7 +54,7 @@
 			// Themes API sub-domain rels
 			Themes: {
 				theme: 'https://themes.api.brightspace.com/rels/theme',
-				themeLogo: 'https://themes.api.brightspace.com/rels/logo',
+				logo: 'https://themes.api.brightspace.com/rels/logo',
 			}
 		},
 		HypermediaClasses: {


### PR DESCRIPTION
Whoops, missed changing this.