### PR TITLE
Adding next-period and previous-period rels

### DIFF
--- a/d2l-hm-constants-behavior.html
+++ b/d2l-hm-constants-behavior.html
@@ -36,7 +36,9 @@
 			Activities: {
 				myActivities: 'https://activities.api.brightspace.com/rels/my-activities',
 				activityUsage: 'https://activities.api.brightspace.com/rels/activity-usage',
-				overdue: 'https://activities.api.brightspace.com/rels/overdue'
+				overdue: 'https://activities.api.brightspace.com/rels/overdue',
+				nextPeriod: 'https://activities.api.brightspace.com/rels/next-period',
+				previousPeriod: 'https://activities.api.brightspace.com/rels/previous-period'
 			},
 			// Parents API sub-domain rels
 			Parents: {


### PR DESCRIPTION
[This PR over here](https://github.com/Brightspace/d2l-upcoming-assessments-ui/pull/41) highlighted that these rels haven't been added yet. Soooo here they are!