### PR TITLE
Add new rels and classes for the richtext concept

### DIFF
--- a/d2l-hm-constants-behavior.html
+++ b/d2l-hm-constants-behavior.html
@@ -41,6 +41,10 @@
 				nextPeriod: 'https://activities.api.brightspace.com/rels/next-period',
 				previousPeriod: 'https://activities.api.brightspace.com/rels/previous-period'
 			},
+			// Assignments
+			Assignments: {
+				instructions: 'https://assignments.api.brightspace.com/rels/instructions'
+			},
 			// Parents API sub-domain rels
 			Parents: {
 				allChildren: 'https://parents.api.brightspace.com/rels/all-my-children'
@@ -55,6 +59,10 @@
 				courseInfo: 'https://folio.api.brightspace.com/rels/CourseInfo',
 				courseList: 'https://folio.api.brightspace.com/rels/CourseList'
 			},
+			// Quizzes API sub-domain rels
+			Quizzes: {
+				description: 'https://quizzes.api.brightspace.com/rels/description'
+			},
 			// Themes API sub-domain rels
 			Themes: {
 				theme: 'https://themes.api.brightspace.com/rels/theme',
@@ -68,7 +76,8 @@
 				userQuizActivity: 'user-quiz-activity'
 			},
 			assignments: {
-				assignment: 'assignment'
+				assignment: 'assignment',
+				instructions: 'instructions'
 			},
 			courseImage: {
 				courseImage: 'course-image',
@@ -94,7 +103,11 @@
 				unpinned: 'unpinned'
 			},
 			quizzes: {
-				quiz: 'quiz'
+				quiz: 'quiz',
+				description: 'description'
+			},
+			text: {
+				richtext: 'richtext'
 			}
 		},
 		HypermediaActions: {


### PR DESCRIPTION
Assignments will now return a sub-entity with richtext instructions, like this:

```
{
	"class": ["assignment"],
	"properties": {
		"name": "On Fleek",
		"dueDate": "2017-09-29T15:25:00.000Z",
		"draft": false
	},
	"entities": [{
		"class": ["attachments"],
		"rel": ["https://assignments.api.brightspace.com/rels/attachments"]
	}, {
		"class": ["richtext", "instructions"],
		"properties": {
			"html": "<p>Get them brows <strong>on fleek</strong>, girl!</p>",
			"text": "Get them brows on fleek, girl!"
		},
		"rel": ["item", "https://assignments.api.brightspace.com/rels/instructions"]
	}],
	"links": [REDACTED],
	"rel": ["https://assignments.api.brightspace.com/rels/assignment"]
}
```

And quizzes will similarly return their description as a richtext sub-entity:

```
{
	"class": ["quiz"],
	"properties": {
		"name": "Tribute"
	},
	"entities": [{
		"class": ["richtext", "description"],
		"properties": {
			"html": "<p>Maggie Reid, I like to put things in the description of my quiz. It makes me feel nice inside.</p>",
			"text": "Maggie Reid, I like to put things in the description of my quiz. It makes me feel nice inside."
		},
		"rel": ["item", "https://quizzes.api.brightspace.com/rels/description"]
	}],
	"links": [REDACTED]
}
```