### PR TITLE
BREAKING: grade becomes user-grade, add grade description entries

### DIFF
--- a/d2l-hm-constants-behavior.html
+++ b/d2l-hm-constants-behavior.html
@@ -66,7 +66,9 @@
 			// Grades API sub-domain rels
 			Grades: {
 				comment: 'https://grades.api.brightspace.com/rels/comment',
-				gradeItem: 'https://grades.api.brightspace.com/rels/grade'
+				description: 'https://grades.api.brightspace.com/rels/description',
+				gradeItem: 'https://grades.api.brightspace.com/rels/grade',
+				userGrade: 'https://grades.api.brightspace.com/rels/user-grade'
 			},
 			// Quizzes API sub-domain rels
 			Quizzes: {
@@ -122,7 +124,9 @@
 				unpinned: 'unpinned'
 			},
 			grades: {
+				description: 'description',
 				grade: 'grade',
+				userGrade: 'user-grade',
 				userGrades: 'user-grades'
 			},
 			quizzes: {

--- a/d2l-hm-constants-behavior.html
+++ b/d2l-hm-constants-behavior.html
@@ -67,7 +67,7 @@
 			Grades: {
 				comment: 'https://grades.api.brightspace.com/rels/comment',
 				description: 'https://grades.api.brightspace.com/rels/description',
-				gradeItem: 'https://grades.api.brightspace.com/rels/grade',
+				grade: 'https://grades.api.brightspace.com/rels/grade',
 				userGrade: 'https://grades.api.brightspace.com/rels/user-grade'
 			},
 			// Quizzes API sub-domain rels


### PR DESCRIPTION
Our initial `grade` rel is really for a `user-grade` and was mis-named. We will shortly be adding a proper `grade` entity which will contain gradeItem information (name, description, etc) as part of [US91652](https://rally1.rallydev.com/#/157196228032d/detail/userstory/168917670620). This PR sets us up for that on the UI side, but as it represents breaking changes (logically) with regards to the existing `grade` rel it will require a major version bump on release.