### PR TITLE
Remove `high` and `low` course image classes

### DIFF
--- a/d2l-hm-constants-behavior.html
+++ b/d2l-hm-constants-behavior.html
@@ -110,8 +110,6 @@
 				min: 'min',
 				mid: 'mid',
 				max: 'max',
-				high: 'high',
-				low: 'low',
 				highDensity: 'high-density',
 				lowDensity: 'low-density'
 			},


### PR DESCRIPTION
These are incorrect. This change will necessitate a major version bump.