### PR TITLE
Add awards rels and classes

### DIFF
--- a/d2l-hm-constants-behavior.html
+++ b/d2l-hm-constants-behavior.html
@@ -21,6 +21,7 @@
 			myEnrollments: 'https://api.brightspace.com/rels/my-enrollments',
 			myNotifications: 'https://notifications.api.brightspace.com/rels/my-notifications',
 			myOrganizationGrades: 'https://api.brightspace.com/rels/my-organization-grades',
+			myOrganizationAwards: 'https://api.brightspace.com/rels/my-organization-awards',
 			userEnrollment: 'https://api.brightspace.com/rels/user-enrollment',
 			organization: 'https://api.brightspace.com/rels/organization',
 			organizationHomepage: 'https://api.brightspace.com/rels/organization-homepage',
@@ -52,6 +53,14 @@
 			Assignments: {
 				instructions: 'https://assignments.api.brightspace.com/rels/instructions',
 				attachments: 'https://assignments.api.brightspace.com/rels/attachments'
+			},
+			// Awards
+			Awards: {
+				courseUserAvailableAwards: 'https://awards.api.brightspace.com/rels/course-user-available-awards',
+				courseUserAwardedAwards: 'https://awards.api.brightspace.com/rels/course-user-awarded-awards',
+				releaseConditions: 'https://awards.api.brightspace.com/rels/release-conditions',
+				userAward: 'https://awards.api.brightspace.com/rels/user-award',
+				userAwards: 'https://awards.api.brightspace.com/rels/user-awards'
 			},
 			// Parents API sub-domain rels
 			Parents: {
@@ -125,6 +134,17 @@
 				submissionComment: 'submission-comment',
 				submissionDate: 'submission-date',
 				submissionList: 'assignment-submission-list'
+			},
+			awards: {
+				available: 'available',
+				awarded: 'awarded',
+				awardImage: 'award-image',
+				badge: 'badge',
+				certificate: 'certificate',
+				releaseCondition: 'release-condition',
+				releaseConditions: 'release-conditions',
+				userAward: 'user-award',
+				userAwards: 'user-awards'
 			},
 			courseImage: {
 				courseImage: 'course-image',


### PR DESCRIPTION
Adds all of the `rels` and `classes` introduced in the awards hypermedia api. Latest values are found in [this PR](https://git.dev.d2l/projects/CUST/repos/awards-service/pull-requests/700/diff#D2L.Awards/WebService/Hypermedia/AwardsSerializer.cs).